### PR TITLE
fix: force install vscode extension

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -149,7 +149,7 @@ install_vscode() {
         log "Installing VS Code extensions..."
         while IFS= read -r ext || [[ -n "$ext" ]]; do
             [[ -z "$ext" || "$ext" =~ ^# ]] && continue
-            code --install-extension "$ext" || true
+            code --install-extension --force "$ext" || true
         done < "${SCRIPT_DIR}/config/code-extensions.txt"
     fi
 


### PR DESCRIPTION
This pull request makes a minor update to the VS Code extension installation process in the `setup.sh` script by ensuring that extensions are always reinstalled, even if they are already present.

* Changed the VS Code extension install command to use the `--force` flag, guaranteeing extensions are reinstalled if already installed.